### PR TITLE
Add option to disable IPv4.

### DIFF
--- a/config.go
+++ b/config.go
@@ -17,7 +17,7 @@ type Config struct {
 type Domain struct {
     Name string `yaml:"NAME"`
     IPv6 bool `yaml:"IPV6"`
-    IPv4 bool `yaml:"IPV4`
+    IPv4 bool `yaml:"IPV4"`
     TTL int `yaml:"TTL"`
     Hosts []string `yaml:"HOSTS"`
 }

--- a/config.go
+++ b/config.go
@@ -36,3 +36,16 @@ func LoadConfig(filename string) (*Config, error) {
 
     return &config, nil
 }
+
+func (d *Domain) UnmarshalYAML(unmarshal func(interface{}) error) error {
+    type rawDomain Domain
+    raw := rawDomain{
+        IPv4: true,
+    }
+    if err := unmarshal(&raw); err != nil {
+        return err
+    }
+
+    *d = Domain(raw)
+    return nil
+}

--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ type Config struct {
 type Domain struct {
     Name string `yaml:"NAME"`
     IPv6 bool `yaml:"IPV6"`
+    IPv4 bool `yaml:"IPV4`
     TTL int `yaml:"TTL"`
     Hosts []string `yaml:"HOSTS"`
 }

--- a/example.yml
+++ b/example.yml
@@ -18,6 +18,8 @@ DOMAINS:
     - NAME: 'example.de' # Your domain name without any subdomains.
       IPV6: true # Whether the 'AAAA' entries of this host should be
                  # updated with the IPv6 address or not.
+      IPV4: true # Whether the 'A' entries of this host should be
+                 # updated with the IPv4 address or not.
       TTL: 300 # Time to live for this zone. Around 300 is good for dyndns.
       HOSTS: # Every host that should get your public ip 
           - '@'
@@ -26,6 +28,7 @@ DOMAINS:
 
     - NAME: 'example.com'
       IPV6: false
+      IPV4: true
       TTL: 350 
       HOSTS:
           - '@'

--- a/example.yml
+++ b/example.yml
@@ -19,7 +19,8 @@ DOMAINS:
       IPV6: true # Whether the 'AAAA' entries of this host should be
                  # updated with the IPv6 address or not.
       IPV4: true # Whether the 'A' entries of this host should be
-                 # updated with the IPv4 address or not.
+                 # updated with the IPv4 address or not. This option defaults
+                 # to true when not present.
       TTL: 300 # Time to live for this zone. Around 300 is good for dyndns.
       HOSTS: # Every host that should get your public ip 
           - '@'


### PR DESCRIPTION
Add an option to disable updating A records for a domain. This is relevant for ISPs that only provide public IPv6 addresses.